### PR TITLE
Add support for email templates

### DIFF
--- a/.github/workflows/python-black.yml
+++ b/.github/workflows/python-black.yml
@@ -1,0 +1,23 @@
+---
+# Perform Python code linting using black
+# Remember to change "./code-folder" to the folder with the code
+name: Black formatting
+
+on: [push, pull_request]
+
+jobs:
+  BlackFormatting:
+    concurrency:
+      group: ${{ github.ref }}-black
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check code formatting with Black
+        uses: psf/black@stable
+        with:
+          options: "-l 100 --check"
+          src: "./form_manager"

--- a/form_manager/config.py
+++ b/form_manager/config.py
@@ -30,6 +30,6 @@ class Config(object):
     MAIL_USE_SSL = False
     MAIL_DEFAULT_SENDER = ("Form Manager", "forms@example.com")
 
-    USER_FILTER = {} # Limits to users that may use the system, e.g. {"email": ["scilifelab.se"]}
+    USER_FILTER = {}  # Limits to users that may use the system, e.g. {"email": ["scilifelab.se"]}
 
     REVERSE_PROXY = False  # Behind a reverse proxy, use X_Forwarded-For to get the ip

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -157,7 +157,7 @@ def delete_form(identifier: str):
         flask.abort(code=403)
     flask.g.db["forms"].delete_one(entry)
     flask.g.db["submissions"].delete_many({"identifier": entry["identifier"]})
-    return flask.Submission(code=200)
+    return ""
 
 
 @csrf.exempt

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -1,5 +1,4 @@
 """Endpoints related to forms."""
-import json
 import pprint
 from bson import ObjectId
 
@@ -18,6 +17,10 @@ def form():
         "title": "",
         "recaptcha_secret": "",
         "email_recipients": [],
+        "email_custom": False,
+        "email_title": "",
+        "email_html_template": "",
+        "email_text_template": "",
         "owners": [],
         "redirect": "",
     }
@@ -184,15 +187,7 @@ def receive_submission(identifier: str):
         del form_submission["g-recaptcha-response"]
 
     if form_info.get("email_recipients"):
-        text_body = json.dumps(form_submission, indent=2, sort_keys=True, ensure_ascii=False)
-        text_body += f"\n\nSubmission received: {utils.make_timestamp()}"
-        mail.send(
-            flask_mail.Message(
-                f"Form from {form_info.get('title')}",
-                body=text_body,
-                recipients=form_info["email_recipients"],
-            )
-        )
+        utils.send_email(form_info, form_submission, mail)
 
     to_add = {
         "submission": form_submission,

--- a/form_manager/user.py
+++ b/form_manager/user.py
@@ -17,7 +17,7 @@ def user_info():
 @blueprint.route("/login")
 def oidc_login():
     """Perform a login using OpenID Connect."""
-    redirect_uri = flask.url_for("user.oidc_authorize", _external=True)        
+    redirect_uri = flask.url_for("user.oidc_authorize", _external=True)
     return oauth.oidc_entry.authorize_redirect(redirect_uri)
 
 
@@ -31,7 +31,7 @@ def oidc_authorize():
     if domain_limit:
         user_email = token.get("userinfo", {}).get("email")
         try:
-            domain = user_email[user_email.index('@')+1:]
+            domain = user_email[user_email.index("@") + 1 :]
         except ValueError:
             flask.abort(400)
         if domain not in domain_limit:

--- a/form_manager/utils.py
+++ b/form_manager/utils.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 import functools
 import os
+import re
 import secrets
 
 import flask
@@ -111,3 +112,25 @@ def has_form_access(username, entry):
         bool: Whether the user has access.
     """
     return username in entry["owners"]
+
+
+def apply_template(template: str, data: dict) -> str:
+    """
+    Fill a template with the values of the defined variables.
+
+    Variables are entered as ``{{ variable }}``.
+    Currently using simple text replacement, but may use Jinja in the future.
+
+    Args:
+        template (str): The template.
+        data (dict): The variables to use.
+
+    Returns:
+        str: The resulting text.
+    """
+    possible_inserts = re.findall(r"{{ (.+?) }}", template)
+    for ins in possible_inserts:
+        if data.get(ins):
+            template = template.replace(f"{{ {ins} }}", data[ins])
+
+    return template

--- a/form_manager/utils.py
+++ b/form_manager/utils.py
@@ -162,9 +162,10 @@ def send_email(form_info: dict, data: dict, mail_client):
     """
     if form_info.get("email_custom"):
         body_text = apply_template(form_info.get("email_text_template", ""), data)
+        body_html = apply_template(form_info.get("email_html_template", ""), data)
     else:
         body_text = gen_json_body(data)
-    body_html = body_text
+        body_html = body_text.replace("\n", "<br/>")
     mail_client.send(
         flask_mail.Message(
             form_info.get("email_title"),

--- a/form_manager/utils.py
+++ b/form_manager/utils.py
@@ -133,8 +133,7 @@ def apply_template(template: str, data: dict) -> str:
     possible_inserts = re.findall(r"{{ (.+?) }}", template)
     for ins in possible_inserts:
         if data.get(ins):
-            template = template.replace(f"{{ {ins} }}", data[ins])
-
+            template = template.replace("{{ " + ins + " }}", data[ins])
     return template
 
 

--- a/frontend/src/components/StringListEditor.vue
+++ b/frontend/src/components/StringListEditor.vue
@@ -8,8 +8,9 @@
       hide-bottom-space
       outlined
       :label="fieldTitle"
-      :rules="[ function (val) { return (evaluateValue(val) || val.length === 0) || 'No whitespace at beginning nor end and must not already exist.' }]">
+      :rules="[ function (val) { return (evaluateValue(val) || val.length === 0) || 'No whitespace at beginning nor end and must not already exist.' }]"
       @keyup.enter="addValue"
+      >
       <template #after>
         <q-btn
 	  icon="add"

--- a/frontend/src/pages/FormBrowser.vue
+++ b/frontend/src/pages/FormBrowser.vue
@@ -130,6 +130,39 @@
 		  />
               </q-item-section>
             </q-item>
+	    <div v-show="editData[props.key].email_recipients.length > 0">
+	    <q-item>
+              <q-item-section>
+		<q-input
+		  v-model="editData[props.key].email_title"
+		  dense
+		  outlined
+		  label="Email title"
+		  />
+              </q-item-section>
+	    </q-item>
+	    <q-item>
+	      <q-item-section>
+		<q-toggle
+		  v-model="editData[props.key].email_custom"
+		  label="Custom email template"
+		  />
+		<q-space />
+		<div v-show="editData[props.key].email_custom">
+		  <q-btn
+		    flat
+		    label="Edit text email"
+		    @click="openTemplateDialog(editData[props.key], 'text')"
+		    />
+		  <q-btn
+		    flat
+		    label="Edit html email"
+		    @click="openTemplateDialog(editData[props.key], 'html')"
+		    />
+		</div>
+	      </q-item-section>
+	    </q-item>
+	    </div>
             <q-item>
               <q-item-section>
 		<str-list-editor
@@ -179,6 +212,56 @@
       </q-tr>
     </template>
   </q-table>
+  <q-dialog v-model="showEditTemplateDialog">
+    <q-card style="min-width: 600px">
+      <q-card-section class="column">
+	<div class="text-h5 q-mb-sm">Edit Email Template</div>
+	<q-input
+	  v-model="currentEditTemplateText"
+	  autogrow
+	  outlined
+	  type="textarea"
+	  />
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn
+	  flat
+          label="Keep"
+          color="positive"
+          @click="saveTemplate" />
+        <q-btn
+	  v-close-popup
+	  flat
+	  label="Cancel"
+	  color="grey-7" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+  <q-dialog v-model="showDeleteWarning">
+    <q-card>
+      <q-card-section class="row items-center">
+        <q-avatar icon="fas fa-trash" color="alert" text-color="primary" />
+        <span class="q-ml-sm">Are you sure you want to delete this form?</span>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn
+	  flat
+          :loading="isDeleting"
+          label="Delete"
+          color="negative"
+          class="user-edit-confirm-delete"
+          @click="deleteEntry" />
+        <q-btn
+	  v-close-popup
+	  flat
+	  label="Cancel"
+	  color="grey-7" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+
 </q-page>
 </template>
 
@@ -197,10 +280,15 @@ export default defineComponent({
     return {
       entries: [],
       editData: {},
+      isDeleting: false,
       filter: '',
       loading: false,
       loadError: false,
-      saveError: false,
+      showEditTemplateDialog: false,
+      showDeleteWarning: false,
+      currrentEditTemplate: {},
+      currrentEditTemplateText: "",
+      currrentEditTemplateType: "",
       pagination: {
         rowsPerPage: 20
       },
@@ -266,7 +354,7 @@ export default defineComponent({
       this.$router.push({name: 'FormResponses', params: {identifier: identifier}});
     },
     deleteForm(entry) {
-      console.log(this.$q.cookies)
+      this.isDeleting = true;
       this.$axios
 	.delete('/api/v1/form/' + entry.row.identifier,
 		{headers: {'X-CSRFToken': this.$q.cookies.get('_csrf_token')}})
@@ -275,6 +363,7 @@ export default defineComponent({
 	  delete this.editData[entry.row.identifier];
 	  this.getEntries();
 	})
+	.finally(() => this.isDeleting = false);
     },
     addForm() {
       this.$axios
@@ -282,22 +371,23 @@ export default defineComponent({
         .then(() => this.getEntries())
     },
     expandItem(entry) {
-      console.log(entry)
       entry.expand = !entry.expand;
       if (!(entry.key in this.editData)) {
 	this.editData[entry.key] = {
 	  title: entry.row.title,
 	  recaptcha_secret: entry.row.recaptcha_secret,
 	  email_recipients: JSON.parse(JSON.stringify(entry.row.email_recipients)),
+	  email_custom: entry.row.email_custom,
+	  email_text_template: entry.row.email_text_template,
+	  email_html_template: entry.row.email_html_template,
+	  email_title: entry.row.email_title,
 	  owners: JSON.parse(JSON.stringify(entry.row.owners)),
 	  redirect: entry.row.redirect,
 	  saving: false,
-	  saveError: false,
 	}
       }
     },
     saveEdit(entry) {
-      this.saveError = false;
       this.editData[entry.key].saving = true;
       this.editData[entry.key].saveError = false;
       let outgoing = JSON.parse(JSON.stringify(this.editData[entry.key]));
@@ -310,12 +400,26 @@ export default defineComponent({
 	  delete this.editData[entry.key];
 	  this.getEntries();
 	  })
-	.catch((err) => this.editData[entry.key].saveError = true)
-	.finally(() => this.editData[entry.key].saving = false);
+	.catch((err) => {
+	  this.editData[entry.key].saveError = true
+	  this.editData[entry.key].saving = false
+	})
     },
     cancelEdit(entry) {
       entry.expand = false;
       delete this.editData[entry.key];
+    },
+    openTemplateDialog(entry, type) {
+      this.showEditTemplateDialog = true;
+      let prop = "email_" + type + "_template";
+      this.currentEditTemplate = entry;
+      console.log(this.currentEditTemplate)
+      this.currentEditTemplateType = prop;
+      this.currentEditTemplateText = entry[prop];
+    },
+    saveTemplate() {
+      this.currentEditTemplate[this.currentEditTemplateType] = this.currentEditTemplateText;
+      this.showEditTemplateDialog = false;
     },
   },
 })

--- a/frontend/src/pages/FormBrowser.vue
+++ b/frontend/src/pages/FormBrowser.vue
@@ -202,7 +202,7 @@
 		    size="md"
 		    icon="delete"
 		    color="negative"
-		    @click="deleteForm(props)" />
+		    @click="confirmDelete(props)" />
 		  <span v-show="editData[props.key].saveError" class="text-negative">Save failed</span>
 		</div>
 	      </q-item-section>
@@ -252,7 +252,7 @@
           label="Delete"
           color="negative"
           class="user-edit-confirm-delete"
-          @click="deleteEntry" />
+          @click="deleteForm" />
         <q-btn
 	  v-close-popup
 	  flat
@@ -281,6 +281,7 @@ export default defineComponent({
       entries: [],
       editData: {},
       isDeleting: false,
+      toDelete: {},
       filter: '',
       loading: false,
       loadError: false,
@@ -353,14 +354,21 @@ export default defineComponent({
     gotoEntry(identifier) {
       this.$router.push({name: 'FormResponses', params: {identifier: identifier}});
     },
-    deleteForm(entry) {
+
+    confirmDelete(entry) {
+      this.toDelete = entry;
+      this.showDeleteWarning = true;
+    },
+
+    deleteForm() {
       this.isDeleting = true;
       this.$axios
-	.delete('/api/v1/form/' + entry.row.identifier,
+	.delete('/api/v1/form/' + this.toDelete.row.identifier,
 		{headers: {'X-CSRFToken': this.$q.cookies.get('_csrf_token')}})
         .then(() => {
-	  entry.expand = false;
-	  delete this.editData[entry.row.identifier];
+	  this.toDelete.expand = false;
+	  this.showDeleteWarning = false;
+	  delete this.editData[this.toDelete.row.identifier];
 	  this.getEntries();
 	})
 	.finally(() => this.isDeleting = false);

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -24,7 +24,26 @@ def test_apply_template():
     }
 
     res = utils.apply_template(BASE_TEMPLATE, data)
+    print(res)
     assert res.count("hit_1") == 2
     assert res.count("hit_2") == 1
     assert "BAD" not in data
     assert "unique }}" not in data
+
+
+def test_gen_json_body():
+    """Test gen_json_body()."""
+    data = {
+        "val": "hit_1",
+        "asd": "hit_2",
+        "variable": "hit_3",
+        "spec_val": "unique",
+        "bad_variable": "BAD",
+    }
+
+    expected = ('{\n  "asd": "hit_2",\n  "bad_variable": "BAD",\n  ',
+                '"spec_val": "unique",\n  "val": "hit_1",\n  "variable": "hit_3"\n}')
+
+    res = utils.gen_json_body(data)
+    assert res.startswith(expected)
+    assert "Submission received:" in res

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,8 +41,10 @@ def test_gen_json_body():
         "bad_variable": "BAD",
     }
 
-    expected = ('{\n  "asd": "hit_2",\n  "bad_variable": "BAD",\n  ',
-                '"spec_val": "unique",\n  "val": "hit_1",\n  "variable": "hit_3"\n}')
+    expected = (
+        '{\n  "asd": "hit_2",\n  "bad_variable": "BAD",\n  ',
+        '"spec_val": "unique",\n  "val": "hit_1",\n  "variable": "hit_3"\n}',
+    )
 
     res = utils.gen_json_body(data)
     assert res.startswith(expected)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,30 @@
+"""Test functions from utils.py"""
+
+from form_manager import utils
+
+BASE_TEMPLATE = """{{ val }} random text here 12345 {{ }}.
+more text here {{ asd }} {{ val }}
+{{
+  bad_variable
+}}
+
+Text here {{ {{ spec_val }} }}
+
+{{ variable }}"""
+
+
+def test_apply_template():
+    """Test apply_template()."""
+    data = {
+        "val": "hit_1",
+        "asd": "hit_2",
+        "variable": "hit_3",
+        "spec_val": "unique",
+        "bad_variable": "BAD",
+    }
+
+    res = utils.apply_template(BASE_TEMPLATE, data)
+    assert res.count("hit_1") == 2
+    assert res.count("hit_2") == 1
+    assert "BAD" not in data
+    assert "unique }}" not in data


### PR DESCRIPTION
* Support for text and html emacs templates
* Confirmation dialog for deleting forms
* Bug fixing

Will require an update to the db:
```
db.forms.updateMany({}, {$set: { "email_custom": false, "email_title": "", "email_html_template": "", "email_text_template": ""}} )
```

Implements #34 
Implements #28 