### PR TITLE
Add env to frontend build, re-enabling it

### DIFF
--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -59,7 +59,9 @@ module.exports = configure(function (/* ctx */) {
         browser: [ 'es2019', 'edge88', 'firefox78', 'chrome87', 'safari13.1' ],
         node: 'node16'
       },
-
+      env: {
+        VERSION: process.env.VERSION,
+      },
       vueRouterMode: 'history', // available values: 'hash', 'history'
       // vueRouterBase,
       // vueDevtools,


### PR DESCRIPTION
The env variable for showing version in the frontend was not re-added after the switch to Vite for the frontend builds. This PR fixes it.