### PR TITLE
Add support for blacklists in the backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,9 @@ services:
       - type: bind
         source: ./test
         target: /code/test
+      - type: bind
+        source: ./form_manager
+        target: /code/form_manager
 
   mailcatcher:
     profiles:

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -206,7 +206,7 @@ def receive_submission(identifier: str):
     # Evaluate Recaptcha
     if form_info.get("recaptcha_secret"):
         if "g-recaptcha-response" not in form_submission or not utils.verify_recaptcha(
-                form_info["recaptcha_secret"], form_submission["g-recaptcha-response"]
+            form_info["recaptcha_secret"], form_submission["g-recaptcha-response"]
         ):
             return flask.redirect(f"/failure{redirect_args}")
         del form_submission["g-recaptcha-response"]

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -201,7 +201,7 @@ def receive_submission(identifier: str):
             flask.current_app.logging.warning("Submission stopped by blacklist")
             flask.redirect(f"/success{redirect_args}")
     except ValueError as err:
-        flask.current_app.logging.error(f"Issue in format of blacklist")
+        flask.current_app.logging.error(f"Issue in format of blacklist: {err}")
 
     # Evaluate Recaptcha
     if form_info.get("recaptcha_secret"):

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -134,15 +134,15 @@ def edit_form(identifier: str):
     """
     indata = flask.request.get_json(silent=True)
     if not indata:
-        flask.abort(code=400)
+        flask.abort(400)
     entry = flask.g.data.fetch_form(identifier)
     if not entry:
-        flask.abort(code=404)
+        flask.abort(404)
     if not utils.has_form_access(flask.session["email"], entry):
-        flask.abort(code=403)
+        flask.abort(403)
     if not validate_form(indata, entry):
         flask.current_app.logger.debug("Validation failed")
-        flask.abort(code=400)
+        flask.abort(400, {"message": "Bad data"})
     entry.update(indata)
     if not flask.g.data.edit_form(entry):
         flask.abort(500, {"message": "Failed to edit form"})
@@ -186,7 +186,7 @@ def receive_submission(identifier: str):
     """
     form_info = flask.g.data.fetch_form(identifier)
     if not form_info:
-        return flask.abort(code=400)
+        return flask.abort(400)
     form_submission = dict(flask.request.form)
 
     if form_info.get("redirect"):
@@ -198,18 +198,21 @@ def receive_submission(identifier: str):
     # the user is reported success, while the entry is silently dropped
     try:
         if utils.is_blacklisted(form_submission, form_info["blacklist"]):
+            flask.current_app.logging.warning("Submission stopped by blacklist")
             flask.redirect(f"/success{redirect_args}")
+    except ValueError as err:
+        flask.current_app.logging.error(f"Issue in format of blacklist")
 
     # Evaluate Recaptcha
     if form_info.get("recaptcha_secret"):
         if "g-recaptcha-response" not in form_submission or not utils.verify_recaptcha(
-            form_info["recaptcha_secret"], form_submission["g-recaptcha-response"]
+                form_info["recaptcha_secret"], form_submission["g-recaptcha-response"]
         ):
             return flask.redirect(f"/failure{redirect_args}")
         del form_submission["g-recaptcha-response"]
 
-    if form_info.get("email_recipients"):
-        utils.send_email(form_info, form_submission, mail)
+        if form_info.get("email_recipients"):
+            utils.send_email(form_info, form_submission, mail)
 
     to_add = {
         "submission": form_submission,

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -19,6 +19,7 @@ def form():
         "email_text_template": "",
         "owners": [],
         "redirect": "",
+        "blacklist": [],
     }
 
 
@@ -184,6 +185,13 @@ def receive_submission(identifier: str):
     else:
         redirect_args = ""
 
+    # Evaluate blacklist; if the submission match a blacklist,
+    # the user is reported success, while the entry is silently dropped
+    try:
+        if utils.is_blacklisted(form_submission, form_info["blacklist"]):
+            flask.redirect(f"/success{redirect_args}")
+
+    # Evaluate Recaptcha
     if form_info.get("recaptcha_secret"):
         if "g-recaptcha-response" not in form_submission or not utils.verify_recaptcha(
             form_info["recaptcha_secret"], form_submission["g-recaptcha-response"]

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -198,10 +198,10 @@ def receive_submission(identifier: str):
     # the user is reported success, while the entry is silently dropped
     try:
         if utils.is_blacklisted(form_submission, form_info["blacklist"]):
-            flask.current_app.logging.warning("Submission stopped by blacklist")
-            flask.redirect(f"/success{redirect_args}")
+            flask.current_app.logger.warning("Submission stopped by blacklist")
+            return flask.redirect(f"/success{redirect_args}")
     except ValueError as err:
-        flask.current_app.logging.error(f"Issue in format of blacklist: {err}")
+        flask.current_app.logger.error(f"Issue in format of blacklist: {err}")
 
     # Evaluate Recaptcha
     if form_info.get("recaptcha_secret"):

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -65,9 +65,18 @@ def validate_form(indata: dict, reference: dict) -> bool:
 def list_forms():
     """List all forms belonging to the current user."""
     form_info = flask.g.data.fetch_forms(flask.session["email"])
-    return flask.jsonify(
-        {"forms": form_info, "url": flask.url_for("forms.list_forms", _external=True)}
-    )
+    outgoing = {"forms": [], "url": flask.url_for("forms.list_forms", _external=True)}
+    for form in form_info:
+        outgoing["forms"].append(
+            {
+                "identifier": form["identifier"],
+                "title": form["title"],
+                "recaptcha": bool(form["recaptcha_secret"]),
+                "email": bool(form["email_recipients"]),
+                "redirect": bool(form["redirect"]),
+            }
+        )
+    return flask.jsonify(outgoing)
 
 
 @blueprint.route("/<identifier>", methods=["GET"])

--- a/form_manager/utils.py
+++ b/form_manager/utils.py
@@ -191,7 +191,7 @@ def is_blacklisted(data: dict, blacklist: list):
                 if re.search(and_entry[key], data[key]):
                     matches += 1
             except re.error as exc:
-                raise ValueError("Bad regex in blacklist") from exc
+                raise ValueError(exc) from exc
         if matches == len(and_entry):
             return True
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,46 @@
 """Test setup."""
+import copy
 
 import pytest
 
 from form_manager import create_app
+import test as helpers
 
 
 @pytest.fixture(scope="function")
 def client():
     app = create_app(testing=True)
     yield app.test_client()
+
+
+FORM = {
+    "identifier": "testFormTestForm",
+    "title": "Test Form",
+    "recaptcha_secret": "",
+    "email_recipients": ["test@example.com"],
+    "email_custom": True,
+    "email_title": "Email from Test Form",
+    "email_html_template": "<p>{{ key }}</p>",
+    "email_text_template": "{{ key }}",
+    "owners": ["test@example.com"],
+    "redirect": "https://www.example.com",
+    "blacklist": [{"blKey": "[0-9]"}],
+}
+
+
+@pytest.fixture(scope="function")
+def form_default():
+    helpers.data_source.add_form(FORM)
+    yield FORM["identifier"]
+    helpers.data_source.delete_form(FORM["identifier"])
+
+
+@pytest.fixture(scope="function")
+def form_bad_bl():
+    entry = copy.deepcopy(FORM)
+    entry["identifier"] = "testFormBadBList"
+    entry["blacklist"] = [{"blKey": "(?)"}]
+
+    helpers.data_source.add_form(entry)
+    yield entry["identifier"]
+    helpers.data_source.delete_form(entry["identifier"])

--- a/test/test_forms.py
+++ b/test/test_forms.py
@@ -80,3 +80,39 @@ def test_add_list_delete_form_not_allowed(client):
     helpers.login(helpers.USERS[0], client)
     response = client.delete(f"/api/v1/form/{identifier}")
     assert response.status_code == 200
+
+
+def test_receive_submission_blacklist_accept(client, form_default):
+    """
+    1. Submit a form
+    2. Verify that it is accepted by the blacklist
+    """
+    data = {"blKey": "abc"}
+    response = client.post(f"/api/v1/form/{form_default}/incoming", data=data)
+    assert response.status_code == 302
+    assert response.location == "/success?redirect=https://www.example.com"
+    assert helpers.data_source.fetch_submissions(form_default)
+
+
+def test_receive_submission_blacklist_reject(client, form_default):
+    """
+    1. Submit a form
+    2. Verify that it is rejected by the blacklist
+    """
+    data = {"blKey": "123"}
+    response = client.post(f"/api/v1/form/{form_default}/incoming", data=data)
+    assert response.status_code == 302
+    assert response.location == "/success?redirect=https://www.example.com"
+    assert not helpers.data_source.fetch_submissions(form_default)
+
+
+def test_receive_submission_blacklist_bad_regex_accept(client, form_bad_bl):
+    """
+    1. Submit a form
+    2. Verify that it is accepted by the blacklist
+    """
+    data = {"blKey": "123"}
+    response = client.post(f"/api/v1/form/{form_bad_bl}/incoming", data=data)
+    assert response.status_code == 302
+    assert response.location == "/success?redirect=https://www.example.com"
+    assert helpers.data_source.fetch_submissions(form_bad_bl)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -42,3 +42,68 @@ def test_gen_json_body():
     res = utils.gen_json_body(data)
     assert res.startswith(expected)
     assert "Submission received:" in res
+
+
+def test_is_blacklisted_match():
+    """Confirm that is_blacklisted detects a match."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key2": "[0-9]"}]
+
+    assert utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_no_match():
+    """Confirm that is_blacklisted does not report a match when there is none."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key2": "[a-zA-Z]"}]
+
+    assert not utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_key_not_present():
+    """Confirm that is_blacklisted does not have issues with non-existing keys."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"characters": "[a-zA-Z]"}]
+
+    assert not utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_key_or_match():
+    """Confirm that is_blacklisted detects a match when one part of an or bl matches."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key2": "[a-zA-Z]"}, {"key": "[a-zA-Z]"}]
+
+    assert utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_key_or_no_match():
+    """Confirm that is_blacklisted detects no match when neither or statement is a match."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key2": "[a-zA-Z]"}, {"key": "[1-9]"}]
+
+    assert not utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_key_and_no_match():
+    """Confirm that is_blacklisted detects no match when not both statements are correct in AND."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key": "[a-zA-Z]", "key2": "[a-zA-Z]"}]
+
+    assert not utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_key_and_match():
+    """Confirm that is_blacklisted detects a match when both statements in AND are matching."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key": "[a-zA-Z]", "key2": "[1-9]"}]
+
+    assert utils.is_blacklisted(bl_data, bl)
+
+
+def test_is_blacklisted_bad_regex():
+    """Confirm that is_blacklisted detects a match when both statements in AND are matching."""
+    bl_data = {"key": "value", "key2": "156"}
+    bl = [{"key": "(?)"}]
+
+    with pytest.raises(ValueError):
+        utils.is_blacklisted(bl_data, bl)


### PR DESCRIPTION
* Adds a `blacklist: []` field to each `form` entry
* `blacklist` is based on a list of dicts, where each key in the blacklist will be matched against the keys in the submission
* Each blacklist value should be a valid regular expression. Match -> submission blocked
