### PR TITLE
FREYA-1157: Update action versions, add Trivy scan workflow, and reformat line length

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run backend tests
         run: docker compose --profile testing up --exit-code-from test

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run backend tests
-        run: docker-compose --profile testing up --exit-code-from test
+        run: docker compose --profile testing up --exit-code-from test
 
       - name: Publish coverage to codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,4 +71,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ main, develop]
 
 jobs:
   analyze:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run setup-qemu-action
         uses: docker/setup-qemu-action@v2
       - name: Run docker/setup-buildx-action

--- a/.github/workflows/python-black.yml
+++ b/.github/workflows/python-black.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check code formatting with Black
         uses: psf/black@stable

--- a/.github/workflows/snyk-code.yml
+++ b/.github/workflows/snyk-code.yml
@@ -23,7 +23,7 @@ jobs:
           command: code test
           args: --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
           category: snyk

--- a/.github/workflows/snyk-code.yml
+++ b/.github/workflows/snyk-code.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 jobs:
   snyk-code-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/trivy-backend.yaml
+++ b/.github/workflows/trivy-backend.yaml
@@ -27,7 +27,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-cron

--- a/.github/workflows/trivy-backend.yaml
+++ b/.github/workflows/trivy-backend.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure lowercase name
         run: echo ORG_NAME=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV

--- a/.github/workflows/trivy-frontend.yaml
+++ b/.github/workflows/trivy-frontend.yaml
@@ -27,7 +27,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-cron

--- a/.github/workflows/trivy-frontend.yaml
+++ b/.github/workflows/trivy-frontend.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure lowercase name
         run: echo ORG_NAME=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -1,0 +1,38 @@
+# Trivy: Scan of current branch
+# Trivy is a comprehensive and versatile security scanner.
+# Trivy has scanners that look for security issues, and targets where it can find those issues.
+# https://github.com/aquasecurity/trivy
+#
+# This runs on every push for every branch
+# ----------------------------------------
+
+name: Trivy - branch scan
+on: [push, pull_request]
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+      security-events: write
+    name: Security Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: trivy-branch

--- a/src/form_manager/forms.py
+++ b/src/form_manager/forms.py
@@ -97,9 +97,7 @@ def fetch_form_info(identifier: str):
     return flask.jsonify(
         {
             "form": entry,
-            "url": flask.url_for(
-                "forms.fetch_form_info", identifier=identifier, _external=True
-            ),
+            "url": flask.url_for("forms.fetch_form_info", identifier=identifier, _external=True),
         }
     )
 
@@ -157,9 +155,7 @@ def edit_form(identifier: str):
             "status": "success",
             "identifier": identifier,
             "type": "PATCH",
-            "url": flask.url_for(
-                "forms.edit_form", identifier=identifier, _external=True
-            ),
+            "url": flask.url_for("forms.edit_form", identifier=identifier, _external=True),
         }
     )
 
@@ -279,9 +275,7 @@ def fetch_submissions(identifier):
     return flask.jsonify(
         {
             "submissions": submissions,
-            "url": flask.url_for(
-                "forms.fetch_submissions", identifier=identifier, _external=True
-            ),
+            "url": flask.url_for("forms.fetch_submissions", identifier=identifier, _external=True),
         }
     )
 

--- a/src/form_manager/mongo.py
+++ b/src/form_manager/mongo.py
@@ -124,11 +124,7 @@ class MongoDatabase(ds.DataSource):
         Returns:
             bool: Whether the submission was deleted successfully.
         """
-        return bool(
-            self._db["submissions"]
-            .delete_one({"_id": ObjectId(identifier)})
-            .deleted_count
-        )
+        return bool(self._db["submissions"].delete_one({"_id": ObjectId(identifier)}).deleted_count)
 
     def close(self):
         """Close the database connection."""

--- a/src/form_manager/pyproject.toml
+++ b/src/form_manager/pyproject.toml
@@ -24,3 +24,6 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.11.2",
 ]
+
+[tool.ruff]
+line-length = 100

--- a/src/form_manager/utils.py
+++ b/src/form_manager/utils.py
@@ -23,9 +23,7 @@ def make_timestamp():
         datetime: The current time.
     """
     fmt = "%a, %d %b %Y %H:%M:%S %Z"
-    return datetime.now(
-        pytz.timezone(os.environ.get("TZ", "Europe/Stockholm"))
-    ).strftime(fmt)
+    return datetime.now(pytz.timezone(os.environ.get("TZ", "Europe/Stockholm"))).strftime(fmt)
 
 
 def verify_recaptcha(secret: str, response: str):
@@ -135,7 +133,9 @@ def send_email(form_info: dict, data: dict, mail_client):
             body_text = apply_template(form_info.get("email_text_template", ""), data)
             body_html = apply_template(form_info.get("email_html_template", ""), data)
         except ValueError:
-            body_text = "There are error(s) in the email template(s), using the default JSON format\n\n"
+            body_text = (
+                "There are error(s) in the email template(s), using the default JSON format\n\n"
+            )
             body_text += gen_json_body(data)
             body_html = body_text.replace("\n", "<br/>")
     else:


### PR DESCRIPTION
- Update CodeQL action versions in the workflows as they were throwing errors about `v2` and `v3` being deprecated.

- Add a new workflow for Trivy scan.

- Reformat with `line-length=100` to make black workflow happy.


Close [FREYA-1157](https://scilifelab.atlassian.net/browse/FREYA-1157).

[FREYA-1157]: https://scilifelab.atlassian.net/browse/FREYA-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ